### PR TITLE
Refactor map initialization and layer management

### DIFF
--- a/projects/embassy/js/map.js
+++ b/projects/embassy/js/map.js
@@ -6,6 +6,7 @@
     max_bounds: true,
     crs: L.CRS.EPSG3857
   });
+  window[mapId] = map;
 
   L.control.scale().addTo(map);
 
@@ -114,7 +115,6 @@
       ).addTo(fg).bindTooltip('<div>\n                     ' + e.name + ' \u2192 ' + c.powerCenter + ': ' + e.dist + ' km\n                 </div>', { sticky: true });
     });
 
-    fg.addTo(map);
     var layerLabel = '<img src="https://flagcdn.com/w40/' + c.code + '.png" width="16" height="10" style="vertical-align:middle;border:1px solid #ccc;border-radius:2px;" alt="' + c.name + '"> ' + c.name;
     overlays[layerLabel] = fg;
     countryFeatureGroups[c.name] = fg;


### PR DESCRIPTION
## Summary
This PR refactors the map initialization and layer management logic to improve map accessibility and defer layer rendering.

## Key Changes
- **Map instance exposure**: Store the map instance in the global window object using the map ID as the key, enabling external access to the map object for programmatic manipulation
- **Deferred layer rendering**: Remove the immediate `fg.addTo(map)` call that was adding feature groups to the map during initialization, allowing layers to be managed through the overlay control system instead

## Implementation Details
The changes separate concerns between map setup and layer visibility management:
- The map object is now globally accessible via `window[mapId]`, which can be useful for debugging, testing, or external integrations
- Feature groups are registered in the `overlays` object and `countryFeatureGroups` map for layer control management, but are no longer automatically added to the map on initialization
- This allows the layer visibility to be controlled through the layer control UI rather than being forced visible at startup

https://claude.ai/code/session_016URFY8xNAPptcB5KhcUFuj