### PR TITLE
VivaTech 2026 : calendrier complet (vues, salles, favoris, import agenda)

### DIFF
--- a/.github/workflows/vivatech-sessions.yml
+++ b/.github/workflows/vivatech-sessions.yml
@@ -1,0 +1,52 @@
+name: Build VivaTech sessions.js
+
+# Régénère projects/vivatech-2026/sessions.js à partir des pages HTML
+# officielles VivaTech committées (officialprogram.html, partners.html,
+# side-events.html), via build_sessions.py.
+#
+# Pourquoi à partir des fichiers committés plutôt qu'en récupérant le site ?
+# vivatech.com est protégé par Cloudflare et renvoie 403 aux clients non
+# navigateur (y compris les runners GitHub) et n'expose pas d'API publique.
+# Le flux fiable est donc : déposer des exports .html à jour dans le dossier,
+# ce workflow reconstruit et committe sessions.js automatiquement.
+
+on:
+  push:
+    paths:
+      - "projects/vivatech-2026/*.html"
+      - "projects/vivatech-2026/build_sessions.py"
+      - ".github/workflows/vivatech-sessions.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: vivatech-sessions-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Régénérer sessions.js
+        working-directory: projects/vivatech-2026
+        run: python3 build_sessions.py
+
+      - name: Committer si modifié
+        run: |
+          if git diff --quiet -- projects/vivatech-2026/sessions.js; then
+            echo "sessions.js déjà à jour — rien à committer."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add projects/vivatech-2026/sessions.js
+            git commit -m "chore: régénère VivaTech sessions.js depuis les pages HTML [skip ci]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Site portfolio personnel - [knoel99.github.io](https://knoel99.github.io/)
 
 | Projet | Description | Stack |
 |---|---|---|
-| [vivatech-2026](https://knoel99.github.io/projects/vivatech-2026/) | Le programme officiel de VivaTech 2026 (413 sessions reelles, 14-20 juin, programme + partenaires + side events) en calendrier clair facon Google Agenda : vues Jour / Semaine / Agenda, selection des salles (calendriers), filtres par theme, recherche, fiche detaillee au clic et import .ics / Google Agenda. Responsive mobile. Genere depuis les pages VivaTech via build_sessions.py | Vanilla JS, Data viz |
+| [vivatech-2026](https://knoel99.github.io/projects/vivatech-2026/) | Le programme officiel de VivaTech 2026 (413 sessions reelles, 14-20 juin, programme + partenaires + side events) en calendrier clair facon Google Agenda : vues Jour / Semaine / Agenda, selection des salles (calendriers), filtres par theme, recherche, fiche detaillee au clic, selection personnelle partageable par URL (Mes sessions, detection de conflits horaires) et import .ics / Google Agenda. Responsive mobile. Genere depuis les pages VivaTech via build_sessions.py | Vanilla JS, Data viz |
 | [jobs-fr](https://knoel99.github.io/projects/jobs-fr/) | Treemap interactif des 1 584 metiers du repertoire ROME, colores par exposition a l'IA | D3.js, France Travail API |
 | [embassy](https://knoel99.github.io/projects/embassy/) | Carte interactive des distances entre les ambassades des pays du G20 et les centres de pouvoir de chaque capitale | Folium, Python, Geopolitique |
 | [deepseek-v4-paper](https://knoel99.github.io/projects/deepseek_v4_paper/) | Lecture guidee du paper DeepSeek-V4 : PDF original a gauche, resume reformule en francais a droite | PDF.js, MoE, LLM |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Site portfolio personnel - [knoel99.github.io](https://knoel99.github.io/)
 
 | Projet | Description | Stack |
 |---|---|---|
-| [vivatech-2026](https://knoel99.github.io/projects/vivatech-2026/) | Le programme officiel de VivaTech 2026 (413 sessions reelles, 14-20 juin, programme + partenaires + side events) reorganise en un calendrier visuel clair : grille horaire par scene, filtres par theme, recherche, vue liste et fiche detaillee au clic. Genere depuis les pages VivaTech via build_sessions.py | Vanilla JS, Data viz |
+| [vivatech-2026](https://knoel99.github.io/projects/vivatech-2026/) | Le programme officiel de VivaTech 2026 (413 sessions reelles, 14-20 juin, programme + partenaires + side events) en calendrier clair facon Google Agenda : vues Jour / Semaine / Agenda, selection des salles (calendriers), filtres par theme, recherche, fiche detaillee au clic et import .ics / Google Agenda. Responsive mobile. Genere depuis les pages VivaTech via build_sessions.py | Vanilla JS, Data viz |
 | [jobs-fr](https://knoel99.github.io/projects/jobs-fr/) | Treemap interactif des 1 584 metiers du repertoire ROME, colores par exposition a l'IA | D3.js, France Travail API |
 | [embassy](https://knoel99.github.io/projects/embassy/) | Carte interactive des distances entre les ambassades des pays du G20 et les centres de pouvoir de chaque capitale | Folium, Python, Geopolitique |
 | [deepseek-v4-paper](https://knoel99.github.io/projects/deepseek_v4_paper/) | Lecture guidee du paper DeepSeek-V4 : PDF original a gauche, resume reformule en francais a droite | PDF.js, MoE, LLM |

--- a/projects/vivatech-2026/index.html
+++ b/projects/vivatech-2026/index.html
@@ -518,6 +518,15 @@ h1 {
 .event .e-fav.on { display: inline-flex; background: #f59e0b; color: #fff; }
 .event.is-fav { box-shadow: 0 0 0 2px #f59e0b, 0 1px 3px rgba(0,0,0,0.12); }
 .wevent.is-fav { box-shadow: 0 0 0 2px #f59e0b; }
+.event.conflict { box-shadow: 0 0 0 2px #dc2626, 0 1px 3px rgba(0,0,0,0.12); }
+.wevent.conflict { box-shadow: 0 0 0 2px #dc2626; }
+.lr-conflict {
+  display: inline-block; font-size: 9.5px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: 0.03em; border-radius: 5px; padding: 1px 6px; margin-left: 6px;
+  background: #fee2e2; color: #b91c1c; vertical-align: middle;
+}
+.dh-warn { color: #b91c1c; font-weight: 600; }
+.mini-btn.copied { background: #dcfce7; border-color: #86efac; color: #166534; }
 
 /* ---------- responsive ---------- */
 @media (max-width: 720px) {
@@ -599,6 +608,10 @@ h1 {
               <span id="favToggleLabel">Mes sessions</span>
             </button>
             <button class="mini-btn" id="themesAll">Tout</button>
+            <button class="mini-btn" id="shareBtn" title="Copier un lien vers cette vue et ma sélection">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+              <span id="shareLabel">Partager</span>
+            </button>
             <button class="mini-btn accent" id="exportBtn" title="Télécharger la sélection au format iCalendar (.ics)">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
               Importer dans mon agenda
@@ -712,14 +725,57 @@ h1 {
   /* ---------- favoris ---------- */
   const favKey = (s) => s.day + "|" + s.start + "|" + s.stage + "|" + s.title;
   const isFav = (s) => state.favs.has(favKey(s));
+  function saveFavs() { try { localStorage.setItem(FAV_KEY, JSON.stringify([...state.favs])); } catch (e) { /* quota / privé */ } }
   function toggleFav(s) {
     const k = favKey(s);
     if (state.favs.has(k)) state.favs.delete(k); else state.favs.add(k);
-    try { localStorage.setItem(FAV_KEY, JSON.stringify([...state.favs])); } catch (e) { /* quota / privé */ }
+    saveFavs();
   }
   const passFav = (s) => !state.favOnly || isFav(s);
   function favSessions() {
     return store.sessions.filter(isFav).sort((a, b) => a.day.localeCompare(b.day) || toMin(a.start) - toMin(b.start));
+  }
+  // Chevauchements horaires au sein de « Mes sessions » (même jour, plages qui se recoupent).
+  function favConflictSet() {
+    const conf = new Set(), byDay = {};
+    favSessions().forEach(s => { (byDay[s.day] = byDay[s.day] || []).push(s); });
+    Object.values(byDay).forEach(arr => {
+      arr.sort((a, b) => toMin(a.start) - toMin(b.start));
+      for (let i = 0; i < arr.length; i++)
+        for (let j = i + 1; j < arr.length; j++)
+          if (toMin(arr[j].start) < toMin(arr[i].end)) { conf.add(favKey(arr[i])); conf.add(favKey(arr[j])); }
+    });
+    return conf;
+  }
+  let favConflicts = new Set();
+  const inConflict = (s) => favConflicts.has(favKey(s));
+
+  /* ---------- état partageable via l'URL (#view=…&day=…&fav=1&sel=…) ---------- */
+  function hashStr(str) { let h = 0; for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0; return h.toString(36); }
+  const shortId = (s) => hashStr(favKey(s));
+  function applyHash() {
+    const h = new URLSearchParams((location.hash || "").replace(/^#/, ""));
+    const v = h.get("view");
+    if (v && ["day", "week", "agenda"].includes(v)) state.view = v;
+    const dy = h.get("day");
+    if (dy && store.days.some(d => d.id === dy)) state.day = dy;
+    const sel = h.get("sel");
+    if (sel) {
+      const want = new Set(sel.split(".").filter(Boolean));
+      const favs = new Set();
+      store.sessions.forEach(s => { if (want.has(shortId(s))) favs.add(favKey(s)); });
+      if (favs.size) { state.favs = favs; state.favOnly = true; saveFavs(); }
+    }
+    if (h.get("fav") === "1") state.favOnly = true;
+  }
+  function syncURL() {
+    const p = new URLSearchParams();
+    p.set("view", state.view);
+    if (state.view !== "week") p.set("day", state.day);
+    if (state.favOnly) p.set("fav", "1");
+    const ids = store.sessions.filter(isFav).map(shortId);
+    if (ids.length) p.set("sel", ids.join("."));
+    history.replaceState(null, "", location.pathname + location.search + "#" + p.toString());
   }
 
   /* ---------- filtres ---------- */
@@ -951,7 +1007,7 @@ h1 {
       const endSlot = Math.min(Math.round((toMin(s.end) - DAY_START) / SLOT_MIN), TOTAL_SLOTS);
       const span = Math.max(2, endSlot - startSlot);
       const ev = document.createElement("div");
-      ev.className = "event" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "");
+      ev.className = "event" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "") + (isFav(s) && inConflict(s) ? " conflict" : "");
       ev.style.gridColumn = (colIdx + 2);
       ev.style.gridRow = (startSlot + 1) + " / span " + span;
       ev.style.background = THEMES[s.theme]?.color || "#666";
@@ -1024,7 +1080,7 @@ h1 {
         const h = Math.max(14, (Math.min(toMin(s.end), END) - toMin(s.start)) * PXMIN - 1);
         const w = 100 / s._ncol;
         const ev = document.createElement("div");
-        ev.className = "wevent" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "");
+        ev.className = "wevent" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "") + (isFav(s) && inConflict(s) ? " conflict" : "");
         ev.style.top = top + "px"; ev.style.height = h + "px";
         ev.style.left = (s._col * w) + "%"; ev.style.width = "calc(" + w + "% - 2px)";
         ev.style.background = THEMES[s.theme]?.color || "#666";
@@ -1087,10 +1143,11 @@ h1 {
         const row = document.createElement("div");
         row.className = "list-row";
         const kindBadge = s.kind === "side" ? `<span class="lr-kind">Side event</span>` : "";
+        const confBadge = (isFav(s) && inConflict(s)) ? `<span class="lr-conflict">⚠ conflit</span>` : "";
         row.innerHTML =
           `<div class="lr-when">${s.start}–${s.end}<span class="stage-pill"></span></div>` +
           `<div>` +
-            `<div class="lr-title"><span class="tdot" style="background:${color}"></span><span class="lr-t"></span>${kindBadge}</div>` +
+            `<div class="lr-title"><span class="tdot" style="background:${color}"></span><span class="lr-t"></span>${kindBadge}${confBadge}</div>` +
             (s.speakers && s.speakers.length ? `<div class="lr-people"></div>` : "") +
           `</div>` +
           `<button class="star-btn lr-star${isFav(s) ? " on" : ""}" title="Ajouter / retirer de Mes sessions">${isFav(s) ? "★" : "☆"}</button>`;
@@ -1186,7 +1243,13 @@ h1 {
   }
 
   /* ---------- rendu global ---------- */
+  function conflictNote() {
+    if (!state.favOnly || !favConflicts.size) return "";
+    const n = favConflicts.size;
+    return ` · <span class="dh-warn">⚠ ${n} session${n > 1 ? "s" : ""} en conflit horaire</span>`;
+  }
   function render() {
+    favConflicts = favConflictSet();
     renderDays();
     renderThemes();
     renderRooms();
@@ -1202,8 +1265,9 @@ h1 {
 
     if (state.view === "week") {
       const total = store.sessions.filter(fullyVisible).length;
-      $("#dayHead").innerHTML = `<strong>Semaine du 14 au 20 juin</strong> · ${total} session${total > 1 ? "s" : ""} affichée${total > 1 ? "s" : ""}`;
+      $("#dayHead").innerHTML = `<strong>Semaine du 14 au 20 juin</strong> · ${total} session${total > 1 ? "s" : ""} affichée${total > 1 ? "s" : ""}` + conflictNote();
       view.appendChild(renderWeek());
+      syncURL();
       return;
     }
 
@@ -1214,15 +1278,17 @@ h1 {
     const count = state.view === "day"
       ? daySessions().filter(s => fullyVisible(s) && isArena(s) && toMin(s.start) < 20 * 60).length
       : daySessions().filter(fullyVisible).length;
-    $("#dayHead").innerHTML = `<strong>${day.full}</strong> · ${day.hours} · ${count} session${count > 1 ? "s" : ""} affichée${count > 1 ? "s" : ""}`;
+    $("#dayHead").innerHTML = `<strong>${day.full}</strong> · ${day.hours} · ${count} session${count > 1 ? "s" : ""} affichée${count > 1 ? "s" : ""}` + conflictNote();
 
     if (daySessions().length === 0) {
       view.innerHTML = `<div class="empty">Le programme du ${day.full} n'est pas encore publié.<br>` +
         `Consultez-le sur <a href="https://vivatech.com/sessions?days=${day.id}" target="_blank" rel="noopener" style="color:var(--accent)">vivatech.com/sessions</a> ` +
         `— il sera ajouté ici dès sa parution.</div>`;
+      syncURL();
       return;
     }
     view.appendChild(state.view === "day" ? renderCalendar() : renderList());
+    syncURL();
   }
 
   /* ---------- événements UI ---------- */
@@ -1254,6 +1320,21 @@ h1 {
       : state.view === "week" ? "VivaTech 2026 — sélection"
       : "VivaTech 2026 — " + (store.days.find(d => d.id === state.day) || {}).full;
     downloadICS(sel, name);
+  });
+
+  // partage : copie un lien reprenant la vue + la sélection (favoris)
+  $("#shareBtn").addEventListener("click", async () => {
+    syncURL();
+    const url = location.href;
+    const label = $("#shareLabel"), btn = $("#shareBtn");
+    const ok = () => { label.textContent = "Lien copié !"; btn.classList.add("copied"); setTimeout(() => { label.textContent = "Partager"; btn.classList.remove("copied"); }, 1800); };
+    try {
+      if (navigator.clipboard && navigator.clipboard.writeText) { await navigator.clipboard.writeText(url); ok(); }
+      else throw new Error("no clipboard");
+    } catch (e) {
+      // repli : sélection manuelle via prompt
+      window.prompt("Copiez ce lien vers votre sélection :", url);
+    }
   });
 
   // fermeture du modal
@@ -1463,6 +1544,8 @@ h1 {
     setStatus("live", override.size);
   }
 
+  // restaure l'état partagé (vue / jour / sélection) depuis l'URL, puis rendu
+  applyHash();
   render();
 
   // Tentative de rafraîchissement en direct, sans bloquer l'affichage initial.

--- a/projects/vivatech-2026/index.html
+++ b/projects/vivatech-2026/index.html
@@ -528,6 +528,34 @@ h1 {
 .dh-warn { color: #b91c1c; font-weight: 600; }
 .mini-btn.copied { background: #dcfce7; border-color: #86efac; color: #166534; }
 
+/* ---------- navigation précédent / suivant dans la fiche ---------- */
+.modal-nav { display: flex; align-items: center; gap: 4px; margin-bottom: 12px; }
+.modal-nav button {
+  width: 30px; height: 30px; border-radius: 8px; cursor: pointer;
+  border: 1px solid var(--line); background: var(--bg2); color: var(--fg);
+  font-size: 18px; line-height: 1; display: inline-flex; align-items: center; justify-content: center;
+}
+.modal-nav button:hover { background: var(--bg3); }
+.modal-nav button:disabled { opacity: 0.4; cursor: default; }
+.modal-nav .m-pos { font-size: 12px; color: var(--fg2); padding: 0 6px; min-width: 52px; text-align: center; }
+
+/* ---------- vue semaine compacte (mobile) ---------- */
+.wk-compact { display: flex; flex-direction: column; gap: 18px; }
+.wkc-day { font-size: 14px; font-weight: 700; color: var(--fg); padding: 6px 0; position: sticky; top: 0; background: var(--bg); border-bottom: 1px solid var(--line); margin-bottom: 4px; z-index: 2; }
+.wkc-day small { font-weight: 500; color: var(--fg2); }
+.wkc-chip { display: grid; grid-template-columns: 86px 1fr auto; gap: 10px; align-items: start; padding: 8px 2px; border-top: 1px solid var(--line2); cursor: pointer; }
+.wkc-chip:first-of-type { border-top: 0; }
+.wkc-chip:hover { background: var(--bg2); }
+.wkc-chip.dim { opacity: 0.4; }
+.wkc-when { font-size: 12px; color: var(--fg2); font-variant-numeric: tabular-nums; }
+.wkc-main { min-width: 0; }
+.wkc-t { font-size: 13.5px; font-weight: 600; display: flex; gap: 7px; align-items: flex-start; }
+.wkc-t .tdot { width: 9px; height: 9px; border-radius: 50%; margin-top: 4px; flex-shrink: 0; }
+.wkc-room { font-size: 11.5px; color: var(--fg2); margin-top: 2px; }
+.wkc-chip.is-fav .wkc-t { text-shadow: none; }
+.wkc-chip.is-fav { box-shadow: inset 3px 0 0 #f59e0b; }
+.wkc-chip.conflict { box-shadow: inset 3px 0 0 #dc2626; }
+
 /* ---------- responsive ---------- */
 @media (max-width: 720px) {
   .top { padding: 26px 16px 14px; }
@@ -645,6 +673,11 @@ h1 {
 <div class="modal-overlay" id="modalOverlay" role="dialog" aria-modal="true">
   <div class="modal" id="modal">
     <div class="modal-head">
+      <div class="modal-nav">
+        <button id="mPrev" title="Session précédente (←)" aria-label="Précédent">‹</button>
+        <span class="m-pos" id="mPos"></span>
+        <button id="mNext" title="Session suivante (→)" aria-label="Suivant">›</button>
+      </div>
       <div class="modal-bar" id="mBar"></div>
       <div class="modal-meta" id="mMeta"></div>
       <h2 id="mTitle"></h2>
@@ -1041,6 +1074,9 @@ h1 {
       note.innerHTML = `Aucune session à afficher.<br>Vérifiez les filtres <strong>Salles</strong> et <strong>Thématiques</strong>.`;
       return note;
     }
+    // sur mobile, la grille horaire à colonnes est illisible : on bascule sur
+    // une version compacte (sections par jour, chips empilés).
+    if (isMobile()) return renderWeekCompact(days, vis);
     const START = Math.floor(Math.min(...vis.map(s => toMin(s.start))) / 30) * 30;
     const END = Math.min(Math.ceil(Math.max(...vis.map(s => toMin(s.end))) / 30) * 30, CAP);
     const H = (END - START) * PXMIN;
@@ -1095,6 +1131,38 @@ h1 {
     });
     scroll.appendChild(body);
     return scroll;
+  }
+
+  // Vue semaine compacte (mobile) : une section par jour, sessions empilées.
+  function renderWeekCompact(days, vis) {
+    const wrap = document.createElement("div");
+    wrap.className = "wk-compact";
+    days.forEach(d => {
+      const sec = document.createElement("div");
+      const head = document.createElement("div");
+      head.className = "wkc-day";
+      const note = d.note === "Side events" ? "side events" : "programme officiel";
+      head.innerHTML = "";
+      head.append(d.full + " ");
+      const sm = document.createElement("small"); sm.textContent = "· " + note; head.appendChild(sm);
+      sec.appendChild(head);
+      vis.filter(s => s.day === d.id).sort((a, b) => toMin(a.start) - toMin(b.start) || a.stage.localeCompare(b.stage)).forEach(s => {
+        const color = THEMES[s.theme]?.color || "#666";
+        const chip = document.createElement("div");
+        chip.className = "wkc-chip" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "") + (isFav(s) && inConflict(s) ? " conflict" : "");
+        chip.innerHTML =
+          `<div class="wkc-when">${s.start}–${s.end}</div>` +
+          `<div class="wkc-main"><div class="wkc-t"><span class="tdot" style="background:${color}"></span><span class="wkc-tt"></span></div><div class="wkc-room"></div></div>` +
+          `<button class="star-btn${isFav(s) ? " on" : ""}" title="Mes sessions">${isFav(s) ? "★" : "☆"}</button>`;
+        chip.querySelector(".wkc-tt").textContent = s.title;
+        chip.querySelector(".wkc-room").textContent = s.stage;
+        chip.querySelector(".star-btn").addEventListener("click", (e) => { e.stopPropagation(); toggleFav(s); render(); });
+        chip.addEventListener("click", () => openModal(s));
+        sec.appendChild(chip);
+      });
+      wrap.appendChild(sec);
+    });
+    return wrap;
   }
 
   // Répartit les événements qui se chevauchent en colonnes (lanes) par grappe.
@@ -1163,9 +1231,39 @@ h1 {
     return wrap;
   }
 
-  /* ---------- modal détail ---------- */
+  /* ---------- modal détail (avec navigation ‹ ›) ---------- */
   const KIND_LABEL = { official: "Programme officiel", partner: "Session partenaire", side: "Side event" };
+  let modalSeq = [], modalIdx = -1;
+
+  // Séquence ordonnée des sessions « navigables » selon la vue active.
+  function buildSequence() {
+    const byTime = (a, b) => toMin(a.start) - toMin(b.start) || a.stage.localeCompare(b.stage);
+    if (state.view === "week") {
+      return store.sessions.filter(s => roomOn(s) && passFav(s) && toMin(s.start) < 20 * 60)
+        .sort((a, b) => a.day.localeCompare(b.day) || byTime(a, b));
+    }
+    if (state.view === "day") {
+      return daySessions().filter(s => isArena(s) && roomOn(s) && passFav(s) && toMin(s.start) < 20 * 60).sort(byTime);
+    }
+    return daySessions().filter(fullyVisible).sort(byTime);
+  }
   function openModal(s) {
+    modalSeq = buildSequence();
+    modalIdx = modalSeq.findIndex(x => favKey(x) === favKey(s));
+    if (modalIdx < 0) { modalSeq = [s]; modalIdx = 0; }
+    fillModal(modalSeq[modalIdx]);
+    $("#modalOverlay").classList.add("open");
+    document.body.style.overflow = "hidden";
+  }
+  function navModal(delta) {
+    if (modalSeq.length < 2) return;
+    modalIdx = (modalIdx + delta + modalSeq.length) % modalSeq.length;
+    fillModal(modalSeq[modalIdx]);
+  }
+  function fillModal(s) {
+    const multi = modalSeq.length > 1;
+    $("#mPrev").style.display = $("#mNext").style.display = $("#mPos").style.display = multi ? "" : "none";
+    if (multi) $("#mPos").textContent = (modalIdx + 1) + " / " + modalSeq.length;
     const color = THEMES[s.theme]?.color || "#666";
     $("#mBar").style.background = color;
     const meta = [];
@@ -1221,9 +1319,6 @@ h1 {
     };
     syncFav();
     favBtn.onclick = () => { toggleFav(s); syncFav(); render(); };
-
-    $("#modalOverlay").classList.add("open");
-    document.body.style.overflow = "hidden";
   }
   function closeModal() {
     $("#modalOverlay").classList.remove("open");
@@ -1337,10 +1432,24 @@ h1 {
     }
   });
 
-  // fermeture du modal
+  // re-rendu au franchissement du seuil mobile (grille semaine ↔ compacte)
+  let _wasMobile = isMobile(), _rsz;
+  window.addEventListener("resize", () => {
+    clearTimeout(_rsz);
+    _rsz = setTimeout(() => { if (isMobile() !== _wasMobile) { _wasMobile = isMobile(); render(); } }, 160);
+  });
+
+  // modal : fermeture + navigation ‹ ›
   $("#mClose").addEventListener("click", closeModal);
+  $("#mPrev").addEventListener("click", () => navModal(-1));
+  $("#mNext").addEventListener("click", () => navModal(1));
   $("#modalOverlay").addEventListener("click", e => { if (e.target === $("#modalOverlay")) closeModal(); });
-  document.addEventListener("keydown", e => { if (e.key === "Escape") closeModal(); });
+  document.addEventListener("keydown", e => {
+    if (!$("#modalOverlay").classList.contains("open")) return;
+    if (e.key === "Escape") closeModal();
+    else if (e.key === "ArrowLeft") navModal(-1);
+    else if (e.key === "ArrowRight") navModal(1);
+  });
 
   /* ============================================================================
      Mise à jour en direct depuis VivaTech (best-effort)

--- a/projects/vivatech-2026/index.html
+++ b/projects/vivatech-2026/index.html
@@ -417,10 +417,108 @@ h1 {
 .modal-desc { font-size: 14px; line-height: 1.6; color: var(--fg); white-space: pre-wrap; }
 .modal-desc.empty { color: var(--fg2); font-style: italic; }
 
+/* ---------- Filtres (thèmes + salles + export) ---------- */
+.filters { margin-top: 14px; display: flex; flex-direction: column; gap: 12px; }
+.filter-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap;
+}
+.filter-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--fg2); }
+.mini-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+.mini-btn {
+  font-family: inherit; font-size: 12px; font-weight: 600;
+  border: 1px solid var(--line); background: var(--bg2); color: var(--fg);
+  border-radius: 8px; padding: 6px 11px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px;
+}
+.mini-btn:hover { background: var(--bg3); }
+.mini-btn.accent { background: var(--accent); border-color: var(--accent); color: #fff; }
+.mini-btn.accent:hover { filter: brightness(1.08); }
+
+/* panneau Salles (calendriers) — repliable */
+.rooms-box { border: 1px solid var(--line); border-radius: 10px; background: var(--bg2); }
+.rooms-box > summary {
+  list-style: none; cursor: pointer; padding: 10px 14px;
+  font-size: 13px; font-weight: 600; display: flex; align-items: center; gap: 8px;
+}
+.rooms-box > summary::-webkit-details-marker { display: none; }
+.rooms-box > summary .chev { transition: transform 0.15s; color: var(--fg2); }
+.rooms-box[open] > summary .chev { transform: rotate(90deg); }
+.rooms-box > summary .count { color: var(--fg2); font-weight: 500; font-size: 12px; }
+.rooms-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 2px 14px; padding: 4px 14px 14px;
+}
+.room-row { display: flex; align-items: center; gap: 8px; padding: 5px 0; font-size: 13px; }
+.room-row label { display: flex; align-items: center; gap: 8px; cursor: pointer; flex: 1; min-width: 0; }
+.room-row input { width: 15px; height: 15px; accent-color: var(--accent); flex-shrink: 0; }
+.room-row .r-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.room-row .r-count { color: var(--fg2); font-size: 11.5px; flex-shrink: 0; }
+.room-row .r-ics {
+  border: 1px solid var(--line); background: var(--bg); color: var(--fg2);
+  border-radius: 6px; width: 26px; height: 24px; cursor: pointer; flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.room-row .r-ics:hover { color: var(--accent); border-color: var(--accent); }
+
+/* ---------- vue semaine ---------- */
+.week-scroll { overflow-x: auto; }
+.week-head { display: flex; position: sticky; top: 0; z-index: 6; background: var(--bg); }
+.week-head .wh-gutter { width: 48px; flex-shrink: 0; }
+.week-head .wh-day {
+  flex: 1; min-width: 140px; text-align: center; padding: 8px 6px;
+  font-size: 12.5px; font-weight: 600; background: var(--bg2);
+  border-left: 1px solid var(--line); border-bottom: 1px solid var(--line);
+}
+.week-head .wh-day small { display: block; font-weight: 500; color: var(--fg2); font-size: 11px; }
+.week-body { display: flex; position: relative; }
+.week-gutter { width: 48px; flex-shrink: 0; position: relative; }
+.week-gutter .wg-hour {
+  position: absolute; right: 6px; font-size: 11px; color: var(--fg2);
+  transform: translateY(-7px); white-space: nowrap;
+}
+.week-col { flex: 1; min-width: 140px; position: relative; border-left: 1px solid var(--line2); }
+.wevent {
+  position: absolute; border-radius: 6px; padding: 3px 5px; color: #fff; overflow: hidden;
+  font-size: 10.5px; line-height: 1.2; cursor: pointer; box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+  border-left: 3px solid rgba(255,255,255,0.55);
+}
+.wevent .we-t { font-weight: 600; }
+.wevent .we-room { opacity: 0.9; font-size: 9.5px; }
+.wevent.dim { opacity: 0.16; }
+
+/* ---------- import dans le modal ---------- */
+.modal-actions { display: flex; gap: 10px; flex-wrap: wrap; margin: 4px 0 20px; }
+.act-btn {
+  font-family: inherit; font-size: 13px; font-weight: 600; text-decoration: none;
+  border-radius: 9px; padding: 9px 14px; cursor: pointer; display: inline-flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line); background: var(--bg2); color: var(--fg);
+}
+.act-btn:hover { background: var(--bg3); }
+.act-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.act-btn.primary:hover { filter: brightness(1.08); }
+
+/* ---------- responsive ---------- */
+@media (max-width: 720px) {
+  .top { padding: 26px 16px 14px; }
+  .controls { padding: 8px 16px 0; }
+  .stage { padding: 16px 12px 60px; }
+  h1 { font-size: 23px; }
+  .subtitle { font-size: 14px; }
+  .days { flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; padding-bottom: 4px; }
+  .day-tab { flex-shrink: 0; }
+  .tools { gap: 8px; }
+  .view-toggle { width: 100%; }
+  .view-toggle button { flex: 1; }
+  .rooms-grid { grid-template-columns: 1fr 1fr; }
+  .modal-overlay { padding: 0; align-items: flex-end; }
+  .modal { max-width: 100%; max-height: 92vh; border-radius: 18px 18px 0 0; }
+  .week-head .wh-day, .week-col { min-width: 116px; }
+}
 @media (max-width: 560px) {
-  h1 { font-size: 24px; }
+  h1 { font-size: 21px; }
   .list-row { grid-template-columns: 1fr; gap: 4px; }
   .lr-when { display: flex; gap: 8px; align-items: center; }
+  .rooms-grid { grid-template-columns: 1fr; }
+  .badge { display: none; }
 }
 </style>
 </head>
@@ -437,7 +535,8 @@ h1 {
   </div>
   <p class="subtitle">
     Le <strong>programme officiel</strong> de la 10ᵉ édition réorganisé en un <strong>calendrier visuel clair</strong> :
-    une grille par scène pour voir toute la journée d'un coup d'œil, des filtres par thème et une recherche —
+    vues <strong>Jour</strong>, <strong>Semaine</strong> et <strong>Agenda</strong>, choix des <strong>salles</strong> à afficher,
+    filtres par thème, recherche, et <strong>import dans votre agenda</strong> (Google, Apple, Outlook) —
     plutôt qu'une <a href="https://vivatech.com/sessions" target="_blank" rel="noopener">liste paginée sur 7 pages</a>.
   </p>
   <p class="disclaimer">
@@ -459,11 +558,40 @@ h1 {
         <input id="search" type="search" placeholder="Rechercher une session, un intervenant…">
       </div>
       <div class="view-toggle" id="viewToggle">
-        <button data-view="cal" class="active">Calendrier</button>
-        <button data-view="list">Liste</button>
+        <button data-view="day" class="active">Jour</button>
+        <button data-view="week">Semaine</button>
+        <button data-view="agenda">Agenda</button>
       </div>
     </div>
-    <div class="themes" id="themes"></div>
+
+    <div class="filters">
+      <div>
+        <div class="filter-head">
+          <span class="filter-label">Thématiques</span>
+          <div class="mini-actions">
+            <button class="mini-btn" id="themesAll">Tout</button>
+            <button class="mini-btn accent" id="exportBtn" title="Télécharger la sélection au format iCalendar (.ics)">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+              Importer dans mon agenda
+            </button>
+          </div>
+        </div>
+        <div class="themes" id="themes"></div>
+      </div>
+
+      <details class="rooms-box" id="roomsBox">
+        <summary>
+          <svg class="chev" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+          Salles &amp; calendriers
+          <span class="count" id="roomsCount"></span>
+        </summary>
+        <div class="mini-actions" style="padding:0 14px 8px">
+          <button class="mini-btn" id="roomsAll">Tout cocher</button>
+          <button class="mini-btn" id="roomsNone">Tout décocher</button>
+        </div>
+        <div class="rooms-grid" id="rooms"></div>
+      </details>
+    </div>
   </div>
 </div>
 
@@ -484,6 +612,16 @@ h1 {
       </button>
     </div>
     <div class="modal-body">
+      <div class="modal-actions">
+        <a class="act-btn primary" id="mGcal" target="_blank" rel="noopener">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+          Google Agenda
+        </a>
+        <button class="act-btn" id="mIcs">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          Télécharger .ics (Apple, Outlook…)
+        </button>
+      </div>
       <div id="mSpeakersWrap">
         <p class="modal-section-title">Intervenants</p>
         <ul class="modal-speakers" id="mSpeakers"></ul>
@@ -513,22 +651,108 @@ h1 {
   // pour ne pas ouvrir sur une grille vide (jours de side events uniquement).
   const defaultDay = (store.days.find(d => d.note !== "Side events") || store.days[0]).id;
 
+  // Regroupement « salle » utilisé par le filtre Calendriers : chaque scène/arène
+  // est un calendrier ; tous les lieux externes (side events) sont regroupés.
+  const SIDE_GROUP = "Side events (hors site)";
+  const isMobile = () => window.matchMedia("(max-width: 720px)").matches;
+
   // état
   let state = {
     day: defaultDay,
-    view: "cal",
+    view: isMobile() ? "agenda" : "day",   // mobile : agenda par défaut (plus lisible)
     query: "",
-    themesOff: new Set(),   // thèmes désactivés
+    themesOff: new Set(),   // thèmes masqués
+    roomsOff: new Set(),    // salles / calendriers masqués (noms de scènes + SIDE_GROUP)
   };
 
   // helpers temps
   const toMin = (hhmm) => { const [h, m] = hhmm.split(":").map(Number); return h * 60 + m; };
-  const fmt = (hhmm) => hhmm;
-
-  // granularité (créneaux de 5 min pour des horaires précis).
-  // Les bornes de la journée sont calculées dynamiquement selon les sessions
-  // réellement programmées (certains jours finissent tard, ex. soirées).
+  const pad = (n) => String(n).padStart(2, "0");
   const SLOT_MIN = 5;
+
+  /* ---------- filtres ---------- */
+  const isArena = (s) => store.stages.indexOf(s.stage) >= 0;
+  const roomKey = (s) => (isArena(s) ? s.stage : SIDE_GROUP);
+  const roomOn = (s) => !state.roomsOff.has(roomKey(s));
+  const themeOn = (s) => !state.themesOff.has(s.theme);
+  function matchesQuery(s) {
+    const q = state.query.trim().toLowerCase();
+    if (!q) return true;
+    return (s.title + " " + (s.speakers || []).join(" ") + " " + s.stage + " " + (s.desc || "")).toLowerCase().includes(q);
+  }
+  // « non atténué » dans les grilles (thème actif + recherche) ; les salles, elles, masquent.
+  const matches = (s) => themeOn(s) && matchesQuery(s);
+  const fullyVisible = (s) => roomOn(s) && themeOn(s) && matchesQuery(s);
+
+  function daySessions() {
+    return store.sessions.filter(s => s.day === state.day);
+  }
+
+  /* ============================================================================
+     Export calendrier : iCalendar (.ics, pour Apple/Outlook/Google) + lien
+     « Ajouter à Google Agenda ». Les horaires VivaTech sont en heure de Paris ;
+     en juin la France est en CEST (UTC+2), on convertit donc en UTC.
+     ========================================================================== */
+  function toUTC(day, hhmm) {
+    const [Y, M, D] = day.split("-").map(Number);
+    const [h, mn] = hhmm.split(":").map(Number);
+    return new Date(Date.UTC(Y, M - 1, D, h, mn) - 120 * 60000); // CEST = UTC+2
+  }
+  function stampUTC(dt) {
+    return dt.getUTCFullYear() + pad(dt.getUTCMonth() + 1) + pad(dt.getUTCDate()) +
+      "T" + pad(dt.getUTCHours()) + pad(dt.getUTCMinutes()) + "00Z";
+  }
+  function uidOf(s) {
+    const base = s.day + s.start + s.stage + s.title;
+    let h = 0; for (let i = 0; i < base.length; i++) h = (h * 31 + base.charCodeAt(i)) >>> 0;
+    return "vt2026-" + h.toString(36) + "@knoel99.github.io";
+  }
+  const icsEsc = (t) => String(t || "").replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\r?\n/g, "\\n");
+  function fold(line) { // pliage des lignes à 73 caractères (RFC 5545)
+    const out = []; let s = line;
+    while (s.length > 73) { out.push(s.slice(0, 73)); s = " " + s.slice(73); }
+    out.push(s); return out.join("\r\n");
+  }
+  function vevent(s) {
+    const det = [];
+    if (s.speakers && s.speakers.length) det.push("Intervenants : " + s.speakers.join(", "));
+    if (s.desc) det.push(s.desc);
+    det.push("Programme : https://vivatech.com/sessions?days=" + s.day);
+    const cat = (THEMES[s.theme] && THEMES[s.theme].label) || "VivaTech";
+    return [
+      "BEGIN:VEVENT", "UID:" + uidOf(s), "DTSTAMP:" + stampUTC(new Date()),
+      "DTSTART:" + stampUTC(toUTC(s.day, s.start)), "DTEND:" + stampUTC(toUTC(s.day, s.end)),
+      "SUMMARY:" + icsEsc(s.title), "LOCATION:" + icsEsc(s.venue || s.stage),
+      "DESCRIPTION:" + icsEsc(det.join("\n\n")), "CATEGORIES:" + icsEsc(cat), "END:VEVENT",
+    ].map(fold).join("\r\n");
+  }
+  function buildICS(sessions, name) {
+    return ["BEGIN:VCALENDAR", "VERSION:2.0", "PRODID:-//knoel99//VivaTech 2026//FR",
+      "CALSCALE:GREGORIAN", "METHOD:PUBLISH", "X-WR-CALNAME:" + icsEsc(name || "VivaTech 2026"),
+      "X-WR-TIMEZONE:Europe/Paris"]
+      .concat(sessions.map(vevent), ["END:VCALENDAR"]).join("\r\n");
+  }
+  function slug(t) { return (t || "vivatech").toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 40) || "vivatech"; }
+  function downloadICS(sessions, name) {
+    if (!sessions.length) { alert("Aucune session à exporter avec les filtres actuels."); return; }
+    const blob = new Blob([buildICS(sessions, name)], { type: "text/calendar;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url; a.download = "vivatech-2026-" + slug(name) + ".ics";
+    document.body.appendChild(a); a.click(); a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
+  }
+  function gcalLink(s) {
+    const det = [];
+    if (s.speakers && s.speakers.length) det.push("Intervenants : " + s.speakers.join(", "));
+    if (s.desc) det.push(s.desc);
+    const p = new URLSearchParams({
+      action: "TEMPLATE", text: s.title,
+      dates: stampUTC(toUTC(s.day, s.start)) + "/" + stampUTC(toUTC(s.day, s.end)),
+      details: det.join("\n\n"), location: s.venue || s.stage,
+    });
+    return "https://calendar.google.com/calendar/render?" + p.toString();
+  }
 
   /* ---------- rendu des contrôles ---------- */
   function renderDays() {
@@ -559,61 +783,86 @@ h1 {
     });
   }
 
-  /* ---------- filtrage ---------- */
-  function matches(s) {
-    if (state.themesOff.has(s.theme)) return false;
-    const q = state.query.trim().toLowerCase();
-    if (!q) return true;
-    const hay = (s.title + " " + (s.speakers || []).join(" ") + " " + s.stage + " " + (s.desc || "")).toLowerCase();
-    return hay.includes(q);
+  // Panneau « Salles & calendriers » : une case par scène + un groupe side events.
+  function renderRooms() {
+    const wrap = $("#rooms");
+    wrap.innerHTML = "";
+    const counts = {};
+    store.sessions.forEach(s => { const k = roomKey(s); counts[k] = (counts[k] || 0) + 1; });
+    const keys = store.stages.slice();
+    if (store.sessions.some(s => !isArena(s))) keys.push(SIDE_GROUP);
+
+    keys.forEach(k => {
+      const row = document.createElement("div");
+      row.className = "room-row";
+      const id = "room-" + slug(k);
+      const cb = document.createElement("input");
+      cb.type = "checkbox"; cb.id = id; cb.checked = !state.roomsOff.has(k);
+      cb.onchange = () => { if (cb.checked) state.roomsOff.delete(k); else state.roomsOff.add(k); render(); };
+      const label = document.createElement("label");
+      label.htmlFor = id;
+      const name = document.createElement("span");
+      name.className = "r-name"; name.textContent = k;
+      const cnt = document.createElement("span");
+      cnt.className = "r-count"; cnt.textContent = counts[k] || 0;
+      label.appendChild(cb); label.appendChild(name); label.appendChild(cnt);
+      const ics = document.createElement("button");
+      ics.className = "r-ics"; ics.title = "Importer le calendrier de « " + k + " » (.ics)";
+      ics.innerHTML = `<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>`;
+      ics.onclick = (e) => {
+        e.preventDefault();
+        const sel = store.sessions.filter(s => roomKey(s) === k).sort((a, b) => a.day.localeCompare(b.day) || toMin(a.start) - toMin(b.start));
+        downloadICS(sel, "VivaTech 2026 — " + k);
+      };
+      row.appendChild(label); row.appendChild(ics);
+      wrap.appendChild(row);
+    });
+    const shown = keys.filter(k => !state.roomsOff.has(k)).length;
+    $("#roomsCount").textContent = `(${shown}/${keys.length})`;
   }
 
-  function daySessions() {
-    return store.sessions.filter(s => s.day === state.day);
-  }
-
-  /* ---------- vue calendrier ---------- */
+  /* ---------- vue jour (scènes en colonnes) ---------- */
   function renderCalendar() {
-    // sessions du jour placées sur une scène/arène connue (colonne de la grille)
-    const onGrid = daySessions().filter(s => store.stages.indexOf(s.stage) >= 0);
+    // colonnes = scènes utilisées ce jour ET cochées dans le filtre Salles
+    const dayArena = daySessions().filter(s => isArena(s));
+    const usedToday = store.stages.filter(st => dayArena.some(s => s.stage === st));
+    const cols = usedToday.filter(st => !state.roomsOff.has(st));
+    const onGrid = dayArena.filter(s => cols.indexOf(s.stage) >= 0);
     if (!onGrid.length) {
       const note = document.createElement("div");
       note.className = "empty";
-      note.innerHTML = `Aucune session sur les scènes principales ce jour-là — ` +
-        `uniquement des <strong>side events</strong> hors site.<br>` +
-        `Basculez en <strong>vue Liste</strong> pour les consulter.`;
+      note.innerHTML = usedToday.length
+        ? `Aucune salle sélectionnée pour ce jour.<br>Cochez des scènes dans <strong>Salles &amp; calendriers</strong>, ou passez en <strong>Agenda</strong>.`
+        : `Aucune session sur les scènes principales ce jour-là — uniquement des <strong>side events</strong> hors site.<br>Basculez en <strong>Agenda</strong> pour les consulter.`;
       return note;
     }
     // bornes dynamiques (arrondies à la demi-heure). On plafonne à 20:00 pour
     // ne pas étirer la grille à cause d'une session isolée en soirée : ces
-    // sessions tardives restent visibles dans la vue Liste.
+    // sessions tardives restent visibles en vue Agenda.
     const CAP = 20 * 60;
     const placeable = onGrid.filter(s => toMin(s.start) < CAP);
     const DAY_START = Math.floor(Math.min(...placeable.map(s => toMin(s.start))) / 30) * 30;
     const DAY_END   = Math.min(Math.ceil(Math.max(...placeable.map(s => toMin(s.end))) / 30) * 30, CAP);
     const TOTAL_SLOTS = (DAY_END - DAY_START) / SLOT_MIN;
 
-    const ncols = store.stages.length;
+    const ncols = cols.length;
     const root = document.createElement("div");
     root.className = "cal-wrap";
     const cal = document.createElement("div");
     cal.className = "cal";
     cal.style.setProperty("--ncols", ncols);
 
-    // en-tête
     const header = document.createElement("div");
     header.className = "cal-header";
     header.style.setProperty("--ncols", ncols);
-    header.innerHTML = `<div class="col-h"></div>` + store.stages.map(s => `<div class="col-h">${s}</div>`).join("");
+    header.innerHTML = `<div class="col-h"></div>` + cols.map(s => `<div class="col-h">${s}</div>`).join("");
     cal.appendChild(header);
 
-    // grille
     const grid = document.createElement("div");
     grid.className = "cal-grid";
     grid.style.setProperty("--ncols", ncols);
     grid.style.gridTemplateRows = "repeat(" + TOTAL_SLOTS + ", var(--slot-h))";
 
-    // fonds de colonnes (séparateurs verticaux)
     for (let c = 0; c < ncols; c++) {
       const bg = document.createElement("div");
       bg.className = "col-bg";
@@ -622,7 +871,6 @@ h1 {
       grid.appendChild(bg);
     }
 
-    // lignes + labels (heures pleines et demi-heures)
     for (let slot = 0; slot < TOTAL_SLOTS; slot++) {
       const min = DAY_START + slot * SLOT_MIN;
       if (min % 60 === 0) {
@@ -633,7 +881,7 @@ h1 {
         const label = document.createElement("div");
         label.className = "time-label";
         label.style.gridRow = (slot + 1);
-        label.textContent = String(Math.floor(min / 60)).padStart(2, "0") + ":00";
+        label.textContent = pad(Math.floor(min / 60)) + ":00";
         grid.appendChild(label);
       } else if (min % 30 === 0) {
         const half = document.createElement("div");
@@ -643,11 +891,9 @@ h1 {
       }
     }
 
-    // événements
-    daySessions().forEach(s => {
-      const colIdx = store.stages.indexOf(s.stage);
-      if (colIdx < 0) return;
-      if (toMin(s.start) >= DAY_END) return;          // session tardive → vue Liste
+    onGrid.forEach(s => {
+      const colIdx = cols.indexOf(s.stage);
+      if (toMin(s.start) >= DAY_END) return;          // session tardive → vue Agenda
       const startSlot = Math.round((toMin(s.start) - DAY_START) / SLOT_MIN);
       const endSlot = Math.min(Math.round((toMin(s.end) - DAY_START) / SLOT_MIN), TOTAL_SLOTS);
       const span = Math.max(2, endSlot - startSlot);
@@ -655,8 +901,7 @@ h1 {
       ev.className = "event" + (matches(s) ? "" : " dim");
       ev.style.gridColumn = (colIdx + 2);
       ev.style.gridRow = (startSlot + 1) + " / span " + span;
-      const color = THEMES[s.theme]?.color || "#666";
-      ev.style.background = color;
+      ev.style.background = THEMES[s.theme]?.color || "#666";
       ev.style.borderLeftColor = "rgba(255,255,255,0.55)";
       ev.title = `${s.start}–${s.end} · ${s.title}\n${s.stage}\n${(s.speakers||[]).join(", ")}`;
       ev.innerHTML =
@@ -674,10 +919,98 @@ h1 {
     return root;
   }
 
-  /* ---------- vue liste ---------- */
+  /* ---------- vue semaine (jours en colonnes, axe horaire partagé) ---------- */
+  function renderWeek() {
+    const PXMIN = 0.95, CAP = 20 * 60;
+    const days = store.days.filter(d => store.sessions.some(s => s.day === d.id && roomOn(s) && toMin(s.start) < CAP));
+    const vis = store.sessions.filter(s => roomOn(s) && toMin(s.start) < CAP && days.some(d => d.id === s.day));
+    if (!vis.length) {
+      const note = document.createElement("div");
+      note.className = "empty";
+      note.innerHTML = `Aucune session à afficher.<br>Vérifiez les filtres <strong>Salles</strong> et <strong>Thématiques</strong>.`;
+      return note;
+    }
+    const START = Math.floor(Math.min(...vis.map(s => toMin(s.start))) / 30) * 30;
+    const END = Math.min(Math.ceil(Math.max(...vis.map(s => toMin(s.end))) / 30) * 30, CAP);
+    const H = (END - START) * PXMIN;
+    const hourPx = 60 * PXMIN;
+
+    const scroll = document.createElement("div");
+    scroll.className = "week-scroll";
+
+    // en-tête (jours)
+    const head = document.createElement("div");
+    head.className = "week-head";
+    head.innerHTML = `<div class="wh-gutter"></div>` +
+      days.map(d => `<div class="wh-day">${d.label}<small>${d.note === "Side events" ? "side events" : (d.id === defaultDay ? "ouverture" : "")}</small></div>`).join("");
+    scroll.appendChild(head);
+
+    // corps
+    const body = document.createElement("div");
+    body.className = "week-body"; body.style.height = H + "px";
+    const gutter = document.createElement("div");
+    gutter.className = "week-gutter"; gutter.style.height = H + "px";
+    for (let m = START; m <= END; m += 60) {
+      const lab = document.createElement("div");
+      lab.className = "wg-hour"; lab.style.top = ((m - START) * PXMIN) + "px";
+      lab.textContent = pad(m / 60 | 0) + ":00";
+      gutter.appendChild(lab);
+    }
+    body.appendChild(gutter);
+
+    const gridBg = `repeating-linear-gradient(to bottom, var(--line2) 0, var(--line2) 1px, transparent 1px, transparent ${hourPx}px)`;
+    days.forEach(d => {
+      const col = document.createElement("div");
+      col.className = "week-col"; col.style.background = gridBg;
+      const evs = vis.filter(s => s.day === d.id);
+      layoutLanes(evs);
+      evs.forEach(s => {
+        const top = (toMin(s.start) - START) * PXMIN;
+        const h = Math.max(14, (Math.min(toMin(s.end), END) - toMin(s.start)) * PXMIN - 1);
+        const w = 100 / s._ncol;
+        const ev = document.createElement("div");
+        ev.className = "wevent" + (matches(s) ? "" : " dim");
+        ev.style.top = top + "px"; ev.style.height = h + "px";
+        ev.style.left = (s._col * w) + "%"; ev.style.width = "calc(" + w + "% - 2px)";
+        ev.style.background = THEMES[s.theme]?.color || "#666";
+        ev.innerHTML = `<div class="we-t"></div><div class="we-room"></div>`;
+        ev.querySelector(".we-t").textContent = s.start + " " + s.title;
+        ev.querySelector(".we-room").textContent = s.stage;
+        ev.title = `${s.start}–${s.end} · ${s.title}\n${s.stage}`;
+        ev.addEventListener("click", () => openModal(s));
+        col.appendChild(ev);
+      });
+      body.appendChild(col);
+    });
+    scroll.appendChild(body);
+    return scroll;
+  }
+
+  // Répartit les événements qui se chevauchent en colonnes (lanes) par grappe.
+  function layoutLanes(evs) {
+    evs.sort((a, b) => toMin(a.start) - toMin(b.start) || toMin(a.end) - toMin(b.end));
+    let cluster = [], colsEnd = [], clusterEnd = -1;
+    const flush = () => {
+      const ncol = Math.max(...cluster.map(e => e._col)) + 1;
+      cluster.forEach(e => { e._ncol = ncol; });
+      cluster = []; colsEnd = []; clusterEnd = -1;
+    };
+    evs.forEach(e => {
+      if (cluster.length && toMin(e.start) >= clusterEnd) flush();
+      let placed = false;
+      for (let i = 0; i < colsEnd.length; i++) {
+        if (toMin(e.start) >= colsEnd[i]) { e._col = i; colsEnd[i] = toMin(e.end); placed = true; break; }
+      }
+      if (!placed) { e._col = colsEnd.length; colsEnd.push(toMin(e.end)); }
+      cluster.push(e); clusterEnd = Math.max(clusterEnd, toMin(e.end));
+    });
+    if (cluster.length) flush();
+  }
+
+  /* ---------- vue agenda (liste chronologique) ---------- */
   function renderList() {
     const sessions = daySessions().slice().sort((a, b) => toMin(a.start) - toMin(b.start) || a.stage.localeCompare(b.stage));
-    const visible = sessions.filter(matches);
+    const visible = sessions.filter(fullyVisible);
     const wrap = document.createElement("div");
     wrap.className = "list";
 
@@ -761,6 +1094,10 @@ h1 {
     if (s.desc && s.desc.trim()) { desc.textContent = s.desc; desc.classList.remove("empty"); }
     else { desc.textContent = "Aucune description fournie par VivaTech pour cette session."; desc.classList.add("empty"); }
 
+    // boutons d'import calendrier
+    $("#mGcal").href = gcalLink(s);
+    $("#mIcs").onclick = () => downloadICS([s], s.title);
+
     $("#modalOverlay").classList.add("open");
     document.body.style.overflow = "hidden";
   }
@@ -772,24 +1109,50 @@ h1 {
     return String(str).replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
   }
 
+  // Sessions actuellement « visibles » (pour l'export .ics de la sélection).
+  function selectionForExport() {
+    if (state.view === "week") {
+      return store.sessions.filter(fullyVisible)
+        .sort((a, b) => a.day.localeCompare(b.day) || toMin(a.start) - toMin(b.start));
+    }
+    return daySessions().filter(fullyVisible).sort((a, b) => toMin(a.start) - toMin(b.start));
+  }
+
   /* ---------- rendu global ---------- */
   function render() {
     renderDays();
     renderThemes();
-
-    const day = store.days.find(d => d.id === state.day);
-    const count = daySessions().filter(matches).length;
-    $("#dayHead").innerHTML = `<strong>${day.full}</strong> · ${day.hours} · ${count} session${count > 1 ? "s" : ""} affichée${count > 1 ? "s" : ""}`;
+    renderRooms();
+    $("#viewToggle").querySelectorAll("button").forEach(b => b.classList.toggle("active", b.dataset.view === state.view));
+    // les onglets de jour ne servent qu'en vues Jour / Agenda
+    $("#days").style.display = state.view === "week" ? "none" : "";
 
     const view = $("#view");
     view.innerHTML = "";
+
+    if (state.view === "week") {
+      const total = store.sessions.filter(fullyVisible).length;
+      $("#dayHead").innerHTML = `<strong>Semaine du 14 au 20 juin</strong> · ${total} session${total > 1 ? "s" : ""} affichée${total > 1 ? "s" : ""}`;
+      view.appendChild(renderWeek());
+      return;
+    }
+
+    const day = store.days.find(d => d.id === state.day) || store.days[0];
+    state.day = day.id;
+    // en vue Jour, on ne compte que les sessions réellement placées sur la grille
+    // (scènes cochées, hors soirées tardives) ; en Agenda, toutes les visibles.
+    const count = state.view === "day"
+      ? daySessions().filter(s => fullyVisible(s) && isArena(s) && toMin(s.start) < 20 * 60).length
+      : daySessions().filter(fullyVisible).length;
+    $("#dayHead").innerHTML = `<strong>${day.full}</strong> · ${day.hours} · ${count} session${count > 1 ? "s" : ""} affichée${count > 1 ? "s" : ""}`;
+
     if (daySessions().length === 0) {
       view.innerHTML = `<div class="empty">Le programme du ${day.full} n'est pas encore publié.<br>` +
         `Consultez-le sur <a href="https://vivatech.com/sessions?days=${day.id}" target="_blank" rel="noopener" style="color:var(--accent)">vivatech.com/sessions</a> ` +
         `— il sera ajouté ici dès sa parution.</div>`;
       return;
     }
-    view.appendChild(state.view === "cal" ? renderCalendar() : renderList());
+    view.appendChild(state.view === "day" ? renderCalendar() : renderList());
   }
 
   /* ---------- événements UI ---------- */
@@ -798,8 +1161,25 @@ h1 {
     const btn = e.target.closest("button");
     if (!btn) return;
     state.view = btn.dataset.view;
-    $("#viewToggle").querySelectorAll("button").forEach(b => b.classList.toggle("active", b === btn));
     render();
+  });
+
+  // filtres : tout afficher (thèmes) / cocher / décocher (salles)
+  $("#themesAll").addEventListener("click", () => { state.themesOff.clear(); render(); });
+  $("#roomsAll").addEventListener("click", () => { state.roomsOff.clear(); render(); });
+  $("#roomsNone").addEventListener("click", () => {
+    state.roomsOff.clear();
+    store.stages.forEach(st => state.roomsOff.add(st));
+    if (store.sessions.some(s => !isArena(s))) state.roomsOff.add(SIDE_GROUP);
+    render();
+  });
+
+  // export .ics de la sélection courante
+  $("#exportBtn").addEventListener("click", () => {
+    const sel = selectionForExport();
+    const name = state.view === "week" ? "VivaTech 2026 — sélection"
+      : "VivaTech 2026 — " + (store.days.find(d => d.id === state.day) || {}).full;
+    downloadICS(sel, name);
   });
 
   // fermeture du modal

--- a/projects/vivatech-2026/index.html
+++ b/projects/vivatech-2026/index.html
@@ -311,10 +311,11 @@ h1 {
 }
 .list-row {
   display: grid;
-  grid-template-columns: 110px 1fr;
+  grid-template-columns: 110px 1fr auto;
   gap: 14px;
   padding: 10px 4px;
   border-radius: 8px;
+  align-items: start;
 }
 .list-row + .list-row { border-top: 1px solid var(--line2); }
 .list-row:hover { background: var(--bg2); }
@@ -495,6 +496,28 @@ h1 {
 .act-btn:hover { background: var(--bg3); }
 .act-btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
 .act-btn.primary:hover { filter: brightness(1.08); }
+.act-btn.fav.on { background: #fef3c7; border-color: #f59e0b; color: #92400e; }
+
+/* ---------- favoris (Mes sessions) ---------- */
+.mini-btn.fav-toggle.on { background: #fef3c7; border-color: #f59e0b; color: #92400e; }
+.star-btn {
+  border: 0; background: transparent; cursor: pointer; padding: 0; line-height: 1;
+  color: var(--fg2); flex-shrink: 0; width: 26px; height: 26px;
+  display: inline-flex; align-items: center; justify-content: center; border-radius: 6px;
+}
+.star-btn:hover { background: var(--bg3); }
+.star-btn.on { color: #f59e0b; }
+.lr-star { align-self: start; margin-top: 1px; }
+.event .e-fav {
+  position: absolute; top: 2px; right: 2px; width: 18px; height: 18px;
+  border: 0; border-radius: 5px; cursor: pointer; padding: 0; line-height: 1;
+  background: rgba(255,255,255,0.18); color: #fff; font-size: 11px;
+  display: none; align-items: center; justify-content: center;
+}
+.event:hover .e-fav { display: inline-flex; }
+.event .e-fav.on { display: inline-flex; background: #f59e0b; color: #fff; }
+.event.is-fav { box-shadow: 0 0 0 2px #f59e0b, 0 1px 3px rgba(0,0,0,0.12); }
+.wevent.is-fav { box-shadow: 0 0 0 2px #f59e0b; }
 
 /* ---------- responsive ---------- */
 @media (max-width: 720px) {
@@ -515,8 +538,9 @@ h1 {
 }
 @media (max-width: 560px) {
   h1 { font-size: 21px; }
-  .list-row { grid-template-columns: 1fr; gap: 4px; }
+  .list-row { grid-template-columns: 1fr; gap: 4px; position: relative; padding-right: 30px; }
   .lr-when { display: flex; gap: 8px; align-items: center; }
+  .lr-star { position: absolute; top: 8px; right: 0; }
   .rooms-grid { grid-template-columns: 1fr; }
   .badge { display: none; }
 }
@@ -536,7 +560,8 @@ h1 {
   <p class="subtitle">
     Le <strong>programme officiel</strong> de la 10ᵉ édition réorganisé en un <strong>calendrier visuel clair</strong> :
     vues <strong>Jour</strong>, <strong>Semaine</strong> et <strong>Agenda</strong>, choix des <strong>salles</strong> à afficher,
-    filtres par thème, recherche, et <strong>import dans votre agenda</strong> (Google, Apple, Outlook) —
+    filtres par thème, recherche, <strong>sélection personnelle</strong> (★ Mes sessions) et
+    <strong>import dans votre agenda</strong> (Google, Apple, Outlook) —
     plutôt qu'une <a href="https://vivatech.com/sessions" target="_blank" rel="noopener">liste paginée sur 7 pages</a>.
   </p>
   <p class="disclaimer">
@@ -569,6 +594,10 @@ h1 {
         <div class="filter-head">
           <span class="filter-label">Thématiques</span>
           <div class="mini-actions">
+            <button class="mini-btn fav-toggle" id="favToggle" title="N'afficher que les sessions que j'ai sélectionnées">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 17.3l-6.2 3.7 1.6-7-5.4-4.7 7.1-.6L12 2l2.9 6.7 7.1.6-5.4 4.7 1.6 7z"/></svg>
+              <span id="favToggleLabel">Mes sessions</span>
+            </button>
             <button class="mini-btn" id="themesAll">Tout</button>
             <button class="mini-btn accent" id="exportBtn" title="Télécharger la sélection au format iCalendar (.ics)">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
@@ -613,6 +642,10 @@ h1 {
     </div>
     <div class="modal-body">
       <div class="modal-actions">
+        <button class="act-btn fav" id="mFav">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 17.3l-6.2 3.7 1.6-7-5.4-4.7 7.1-.6L12 2l2.9 6.7 7.1.6-5.4 4.7 1.6 7z"/></svg>
+          <span id="mFavLabel">Ajouter à ma sélection</span>
+        </button>
         <a class="act-btn primary" id="mGcal" target="_blank" rel="noopener">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
           Google Agenda
@@ -656,6 +689,10 @@ h1 {
   const SIDE_GROUP = "Side events (hors site)";
   const isMobile = () => window.matchMedia("(max-width: 720px)").matches;
 
+  // favoris (« Mes sessions ») persistés dans le navigateur
+  const FAV_KEY = "vt2026.favs";
+  function loadFavs() { try { return new Set(JSON.parse(localStorage.getItem(FAV_KEY) || "[]")); } catch (e) { return new Set(); } }
+
   // état
   let state = {
     day: defaultDay,
@@ -663,12 +700,27 @@ h1 {
     query: "",
     themesOff: new Set(),   // thèmes masqués
     roomsOff: new Set(),    // salles / calendriers masqués (noms de scènes + SIDE_GROUP)
+    favs: loadFavs(),       // clés des sessions sélectionnées
+    favOnly: false,         // n'afficher que « Mes sessions »
   };
 
   // helpers temps
   const toMin = (hhmm) => { const [h, m] = hhmm.split(":").map(Number); return h * 60 + m; };
   const pad = (n) => String(n).padStart(2, "0");
   const SLOT_MIN = 5;
+
+  /* ---------- favoris ---------- */
+  const favKey = (s) => s.day + "|" + s.start + "|" + s.stage + "|" + s.title;
+  const isFav = (s) => state.favs.has(favKey(s));
+  function toggleFav(s) {
+    const k = favKey(s);
+    if (state.favs.has(k)) state.favs.delete(k); else state.favs.add(k);
+    try { localStorage.setItem(FAV_KEY, JSON.stringify([...state.favs])); } catch (e) { /* quota / privé */ }
+  }
+  const passFav = (s) => !state.favOnly || isFav(s);
+  function favSessions() {
+    return store.sessions.filter(isFav).sort((a, b) => a.day.localeCompare(b.day) || toMin(a.start) - toMin(b.start));
+  }
 
   /* ---------- filtres ---------- */
   const isArena = (s) => store.stages.indexOf(s.stage) >= 0;
@@ -682,7 +734,7 @@ h1 {
   }
   // « non atténué » dans les grilles (thème actif + recherche) ; les salles, elles, masquent.
   const matches = (s) => themeOn(s) && matchesQuery(s);
-  const fullyVisible = (s) => roomOn(s) && themeOn(s) && matchesQuery(s);
+  const fullyVisible = (s) => roomOn(s) && themeOn(s) && matchesQuery(s) && passFav(s);
 
   function daySessions() {
     return store.sessions.filter(s => s.day === state.day);
@@ -823,17 +875,18 @@ h1 {
 
   /* ---------- vue jour (scènes en colonnes) ---------- */
   function renderCalendar() {
-    // colonnes = scènes utilisées ce jour ET cochées dans le filtre Salles
-    const dayArena = daySessions().filter(s => isArena(s));
-    const usedToday = store.stages.filter(st => dayArena.some(s => s.stage === st));
-    const cols = usedToday.filter(st => !state.roomsOff.has(st));
-    const onGrid = dayArena.filter(s => cols.indexOf(s.stage) >= 0);
+    // colonnes = scènes utilisées ce jour, cochées (Salles) et passant le filtre favoris
+    const anyArena = daySessions().some(s => isArena(s));
+    const onGrid = daySessions().filter(s => isArena(s) && roomOn(s) && passFav(s));
+    const cols = store.stages.filter(st => onGrid.some(s => s.stage === st));
     if (!onGrid.length) {
       const note = document.createElement("div");
       note.className = "empty";
-      note.innerHTML = usedToday.length
-        ? `Aucune salle sélectionnée pour ce jour.<br>Cochez des scènes dans <strong>Salles &amp; calendriers</strong>, ou passez en <strong>Agenda</strong>.`
-        : `Aucune session sur les scènes principales ce jour-là — uniquement des <strong>side events</strong> hors site.<br>Basculez en <strong>Agenda</strong> pour les consulter.`;
+      note.innerHTML = !anyArena
+        ? `Aucune session sur les scènes principales ce jour-là — uniquement des <strong>side events</strong> hors site.<br>Basculez en <strong>Agenda</strong> pour les consulter.`
+        : state.favOnly
+          ? `Aucune session sélectionnée ce jour-là.<br>Cliquez l'étoile ☆ d'une session pour l'ajouter à <strong>Mes sessions</strong>.`
+          : `Aucune salle sélectionnée pour ce jour.<br>Cochez des scènes dans <strong>Salles &amp; calendriers</strong>, ou passez en <strong>Agenda</strong>.`;
       return note;
     }
     // bornes dynamiques (arrondies à la demi-heure). On plafonne à 20:00 pour
@@ -898,7 +951,7 @@ h1 {
       const endSlot = Math.min(Math.round((toMin(s.end) - DAY_START) / SLOT_MIN), TOTAL_SLOTS);
       const span = Math.max(2, endSlot - startSlot);
       const ev = document.createElement("div");
-      ev.className = "event" + (matches(s) ? "" : " dim");
+      ev.className = "event" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "");
       ev.style.gridColumn = (colIdx + 2);
       ev.style.gridRow = (startSlot + 1) + " / span " + span;
       ev.style.background = THEMES[s.theme]?.color || "#666";
@@ -907,9 +960,11 @@ h1 {
       ev.innerHTML =
         `<span class="e-time">${s.start}–${s.end}</span>` +
         `<span class="e-title"></span>` +
-        (s.speakers && s.speakers.length ? `<span class="e-people"></span>` : "");
+        (s.speakers && s.speakers.length ? `<span class="e-people"></span>` : "") +
+        `<button class="e-fav${isFav(s) ? " on" : ""}" title="Ajouter / retirer de Mes sessions">${isFav(s) ? "★" : "☆"}</button>`;
       ev.querySelector(".e-title").textContent = s.title;
       if (s.speakers && s.speakers.length) ev.querySelector(".e-people").textContent = s.speakers.join(", ");
+      ev.querySelector(".e-fav").addEventListener("click", (e) => { e.stopPropagation(); toggleFav(s); render(); });
       ev.addEventListener("click", () => openModal(s));
       grid.appendChild(ev);
     });
@@ -922,8 +977,8 @@ h1 {
   /* ---------- vue semaine (jours en colonnes, axe horaire partagé) ---------- */
   function renderWeek() {
     const PXMIN = 0.95, CAP = 20 * 60;
-    const days = store.days.filter(d => store.sessions.some(s => s.day === d.id && roomOn(s) && toMin(s.start) < CAP));
-    const vis = store.sessions.filter(s => roomOn(s) && toMin(s.start) < CAP && days.some(d => d.id === s.day));
+    const days = store.days.filter(d => store.sessions.some(s => s.day === d.id && roomOn(s) && passFav(s) && toMin(s.start) < CAP));
+    const vis = store.sessions.filter(s => roomOn(s) && passFav(s) && toMin(s.start) < CAP && days.some(d => d.id === s.day));
     if (!vis.length) {
       const note = document.createElement("div");
       note.className = "empty";
@@ -969,7 +1024,7 @@ h1 {
         const h = Math.max(14, (Math.min(toMin(s.end), END) - toMin(s.start)) * PXMIN - 1);
         const w = 100 / s._ncol;
         const ev = document.createElement("div");
-        ev.className = "wevent" + (matches(s) ? "" : " dim");
+        ev.className = "wevent" + (matches(s) ? "" : " dim") + (isFav(s) ? " is-fav" : "");
         ev.style.top = top + "px"; ev.style.height = h + "px";
         ev.style.left = (s._col * w) + "%"; ev.style.width = "calc(" + w + "% - 2px)";
         ev.style.background = THEMES[s.theme]?.color || "#666";
@@ -1037,10 +1092,12 @@ h1 {
           `<div>` +
             `<div class="lr-title"><span class="tdot" style="background:${color}"></span><span class="lr-t"></span>${kindBadge}</div>` +
             (s.speakers && s.speakers.length ? `<div class="lr-people"></div>` : "") +
-          `</div>`;
+          `</div>` +
+          `<button class="star-btn lr-star${isFav(s) ? " on" : ""}" title="Ajouter / retirer de Mes sessions">${isFav(s) ? "★" : "☆"}</button>`;
         row.querySelector(".stage-pill").textContent = s.stage;
         row.querySelector(".lr-t").textContent = s.title;
         if (s.speakers && s.speakers.length) row.querySelector(".lr-people").textContent = s.speakers.join(", ");
+        row.querySelector(".lr-star").addEventListener("click", (e) => { e.stopPropagation(); toggleFav(s); render(); });
         row.addEventListener("click", () => openModal(s));
         block.appendChild(row);
       });
@@ -1098,6 +1155,16 @@ h1 {
     $("#mGcal").href = gcalLink(s);
     $("#mIcs").onclick = () => downloadICS([s], s.title);
 
+    // bouton favori (Mes sessions)
+    const favBtn = $("#mFav");
+    const syncFav = () => {
+      const on = isFav(s);
+      favBtn.classList.toggle("on", on);
+      $("#mFavLabel").textContent = on ? "Retirer de ma sélection" : "Ajouter à ma sélection";
+    };
+    syncFav();
+    favBtn.onclick = () => { toggleFav(s); syncFav(); render(); };
+
     $("#modalOverlay").classList.add("open");
     document.body.style.overflow = "hidden";
   }
@@ -1124,6 +1191,9 @@ h1 {
     renderThemes();
     renderRooms();
     $("#viewToggle").querySelectorAll("button").forEach(b => b.classList.toggle("active", b.dataset.view === state.view));
+    const favN = state.favs.size;
+    $("#favToggle").classList.toggle("on", state.favOnly);
+    $("#favToggleLabel").textContent = favN ? `Mes sessions (${favN})` : "Mes sessions";
     // les onglets de jour ne servent qu'en vues Jour / Agenda
     $("#days").style.display = state.view === "week" ? "none" : "";
 
@@ -1164,6 +1234,9 @@ h1 {
     render();
   });
 
+  // « Mes sessions » : n'afficher que les favoris
+  $("#favToggle").addEventListener("click", () => { state.favOnly = !state.favOnly; render(); });
+
   // filtres : tout afficher (thèmes) / cocher / décocher (salles)
   $("#themesAll").addEventListener("click", () => { state.themesOff.clear(); render(); });
   $("#roomsAll").addEventListener("click", () => { state.roomsOff.clear(); render(); });
@@ -1177,7 +1250,8 @@ h1 {
   // export .ics de la sélection courante
   $("#exportBtn").addEventListener("click", () => {
     const sel = selectionForExport();
-    const name = state.view === "week" ? "VivaTech 2026 — sélection"
+    const name = state.favOnly ? "VivaTech 2026 — ma sélection"
+      : state.view === "week" ? "VivaTech 2026 — sélection"
       : "VivaTech 2026 — " + (store.days.find(d => d.id === state.day) || {}).full;
     downloadICS(sel, name);
   });


### PR DESCRIPTION
## Résumé

Refonte du projet **VivaTech 2026** en un calendrier clair façon Google Agenda, alimenté par les données officielles VivaTech (programme principal + partenaires + side events).

### Données
- **413 sessions réelles** (14–20 juin) extraites des pages HTML officielles, chacune avec son **descriptif complet**, intervenants, lieu et type (officiel / side event).
- `build_sessions.py` régénère `sessions.js` depuis les pages HTML ; **GitHub Action** qui le relance et committe automatiquement quand les `.html` changent.
- Tentative de **synchro en direct** depuis vivatech.com dans le navigateur (fetch direct → proxys CORS), avec repli sur l'instantané embarqué (VivaTech est protégé par Cloudflare / sans API CORS publique).

### Interface
- **3 vues** : Jour (scènes en colonnes), Semaine (axe horaire partagé, version compacte sur mobile), Agenda.
- **Salles & calendriers** : on choisit les scènes à afficher, avec export `.ics` par salle.
- **Filtres** par thématique + recherche (titres, intervenants, descriptions).
- **Fiche détail** au clic, avec navigation ‹ › (clavier ←/→).
- **Mes sessions** : favoris persistés (localStorage), **partageables par URL**, avec **détection de conflits horaires**.
- **Import agenda** : lien Google Agenda + `.ics` (Apple/Outlook) par session, par salle, ou pour la sélection.
- **Responsive mobile** (agenda par défaut, modal bottom-sheet, semaine compacte).

### Tests
Vérifié en DOM headless (les 3 vues, filtres salles/thèmes, recherche, favoris + persistance + conflits, partage/restauration par URL, navigation modale, semaine compacte mobile, export `.ics`) — aucune erreur JS. `build_sessions.py` idempotent, workflow YAML validé.

🤖 https://claude.ai/code/session_01E4Awy96a4xf3q8FmnbQR3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4Awy96a4xf3q8FmnbQR3c)_